### PR TITLE
feat: add GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,25 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [master]
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: npm ci
+
+      - run: npm run build -- --base-href=/keyword-search/ --configuration=production
+
+      - uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./dist/ng-code-test/browser

--- a/package-lock.json
+++ b/package-lock.json
@@ -5360,6 +5360,17 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
+      }
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.60.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",


### PR DESCRIPTION
This PR adds a GitHub Actions workflow that deploys the app to GitHub Pages at `https://ricardoreais.github.io/keyword-search/` on every push to `master`.

## Changes
- `.github/workflows/deploy.yml` — workflow triggered on push to master that builds the Angular app with `--base-href=/keyword-search/` and publishes to the `gh-pages` branch using `peaceiris/actions-gh-pages`
- `package-lock.json` — adds missing `@popperjs/core` peer dependency

## How to enable
Once merged, go to **Settings → Pages** and set **Source** to **Deploy from a branch** → **gh-pages** → **/ (root)**.